### PR TITLE
Update Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: ruby
 
 rvm:
-  - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.1
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
   - ruby-head
 
 cache: bundler


### PR DESCRIPTION
- Drop testing with Ruby 2.3. Because it has been EOL. We do not need to support it actively.
- Update Ruby teeny versions